### PR TITLE
feat: add Dockerfile for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.next
+node_modules
+.env.local
+.env.development.local
+.env.test.local
+.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Stage 1: Install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Stage 2: Build the application
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+# Stage 3: Production image
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["wget", "-q", "-O", "-", "http://localhost:3000"] || exit 1
+
+CMD ["npm", "start"]


### PR DESCRIPTION
This pull request introduces a multi-stage Dockerfile to containerize the Next.js application for production environments.

Key Features:

Multi-Stage Build: Separates the build environment from the runtime environment to create a small and secure final image.
Optimized for Production: Uses the lightweight node:20-alpine base image and copies only the necessary production artifacts (.next, public, node_modules, [package.json](code-assist-path:c:\Leznerr's Domain\CS-NIS SUBJECTS\Y2-1\CSINTSY\boko\lscs-mls-web\package.json)).
Health Check: Includes a HEALTHCHECK instruction to allow Docker to verify that the container is running properly.
.dockerignore: A .dockerignore file has been added to exclude unnecessary files from the build context, speeding up the build process and reducing image size.

I tested it by:
1. Build the Docker image:
docker build -t lscs-mls-web .

2. Run the Docker container:
docker run -d -p 3000:3000 --name lscs-mls-web 

3. Access the application at http://localhost:3000.


GITHUB ISSUE #3 

